### PR TITLE
add human readable (but unstable) section indices like "1.3.1"

### DIFF
--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -5,6 +5,7 @@
   }
 </style>
 
+{% unless include.list.size == 0 %}
 <nav class="breadcrumbs">
   {% for resource in include.list %}
     <a href="{{resource.url | relative_url}}">
@@ -19,3 +20,4 @@
     /
   {% endfor %}
 </nav>
+{% endunless %}

--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -1,0 +1,21 @@
+<style>
+  .breadcrumbs {
+    font-size: small;
+    margin-bottom: .7em;
+  }
+</style>
+
+<nav class="breadcrumbs">
+  {% for resource in include.list %}
+    <a href="{{resource.url | relative_url}}">
+      {% if resource.collection == "nodes" %}
+      <span class="numbering">{{ resource.iso_2145 | append: "." }}</span>
+      {% endif %}
+      {{resource.title}}
+      {% if resource.collection == "nodes" %}
+      <span class="slug">[{{resource.slug}}]</span>
+      {% endif %}
+    </a>
+    /
+  {% endfor %}
+</nav>

--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -1,7 +1,7 @@
 <style>
   .breadcrumbs {
     font-size: small;
-    margin-bottom: .7em;
+    margin-bottom: 1.5em;
   }
 </style>
 

--- a/_includes/list.html
+++ b/_includes/list.html
@@ -2,7 +2,9 @@
   {% for resource in include.list %}
   <li>
     <a href="{{resource.url | relative_url}}">
-      {{resource.numbering}}
+      {% if resource.collection == "nodes" %}
+      <span class="numbering">{{ resource.iso_2145 | append: "." }}</span>
+      {% endif %}
       {{resource.title}}
       {% if resource.collection == "nodes" %}
       <span class="slug">[{{resource.slug}}]</span>

--- a/_includes/list.html
+++ b/_includes/list.html
@@ -2,6 +2,7 @@
   {% for resource in include.list %}
   <li>
     <a href="{{resource.url | relative_url}}">
+      {{resource.breadcrumb}}
       {{resource.title}}
       {% if resource.collection == "nodes" %}
       <span class="slug">[{{resource.slug}}]</span>

--- a/_includes/list.html
+++ b/_includes/list.html
@@ -2,7 +2,7 @@
   {% for resource in include.list %}
   <li>
     <a href="{{resource.url | relative_url}}">
-      {{resource.breadcrumb}}
+      {{resource.numbering}}
       {{resource.title}}
       {% if resource.collection == "nodes" %}
       <span class="slug">[{{resource.slug}}]</span>

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -1,8 +1,9 @@
 <ul class="toc">
   {% for resource in include.page.children %}
   <li>
-    <a class="slug" href="{{resource.url | relative_url}}">[{{resource.slug}}]</a>
+    {{ resource.breadcrumb }}
     <a href="#{{resource.slug}}">{{resource.title}}</a>
+    <a class="slug" href="{{resource.url | relative_url}}">[{{resource.slug}}]</a>
     {% include toc.html page=resource %}
   </li>
   {% endfor %}

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -1,7 +1,7 @@
 <ul class="toc">
   {% for resource in include.page.children %}
   <li>
-    {{ resource.numbering }}
+    {{ resource.iso_2145 | append: "." }}
     <a href="#{{resource.slug}}">{{resource.title}}</a>
     <a class="slug" href="{{resource.url | relative_url}}">[{{resource.slug}}]</a>
     {% include toc.html page=resource %}

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -1,7 +1,7 @@
 <ul class="toc">
   {% for resource in include.page.children %}
   <li>
-    {{ resource.breadcrumb }}
+    {{ resource.numbering }}
     <a href="#{{resource.slug}}">{{resource.title}}</a>
     <a class="slug" href="{{resource.url | relative_url}}">[{{resource.slug}}]</a>
     {% include toc.html page=resource %}

--- a/_layouts/node.html
+++ b/_layouts/node.html
@@ -6,6 +6,7 @@ layout: default
 
   <header class="post-header">
     <h1 class="post-title">
+      {{ page.breadcrumb }}
       {{ page.title | escape }}
       {% if page.collection == "nodes" %}
       <span class="slug">[{{page.slug}}]</span>

--- a/_layouts/node.html
+++ b/_layouts/node.html
@@ -6,7 +6,7 @@ layout: default
 
   <header class="post-header">
     <h1 class="post-title">
-      {{ page.breadcrumb }}
+      {{ page.numbering }}
       {{ page.title | escape }}
       {% if page.collection == "nodes" %}
       <span class="slug">[{{page.slug}}]</span>

--- a/_layouts/node.html
+++ b/_layouts/node.html
@@ -35,13 +35,6 @@ layout: default
     {{ content }}
   </div>
 
-  {% if page.parents.size != 0 %}
-  <nav>
-    <h4>Context</h4>
-    {% include list.html list=page.parents %}
-  </nav>
-  {% endif %}
-
   {% if page.referrers.size != 0 %}
   <nav>
     <h4>Referrers</h4>

--- a/_layouts/node.html
+++ b/_layouts/node.html
@@ -5,6 +5,8 @@ layout: default
 <article class="post">
 
   <header class="post-header">
+    {% include breadcrumbs.html list=page.ancestors %}
+
     <h1 class="post-title">
       {% if page.collection == "nodes" %}
       <span class="numbering">{{ page.iso_2145 | append: "." }}</span>

--- a/_layouts/node.html
+++ b/_layouts/node.html
@@ -6,7 +6,9 @@ layout: default
 
   <header class="post-header">
     <h1 class="post-title">
-      {{ page.numbering }}
+      {% if page.collection == "nodes" %}
+      <span class="numbering">{{ page.iso_2145 | append: "." }}</span>
+      {% endif %}
       {{ page.title | escape }}
       {% if page.collection == "nodes" %}
       <span class="slug">[{{page.slug}}]</span>

--- a/_plugins/sheafy.rb
+++ b/_plugins/sheafy.rb
@@ -77,8 +77,6 @@ module Sheafy
     end
     tsorted_nodes = graph.topologically_sorted
 
-    # TODO: catch TSort::Cyclic and provide meaningful message
-
     # Top. order is good to denormalize data from leaves up to roots,
     # i.e. to do destructive procedures which need the altered children.
     # tsorted_nodes.each { |resource| ... }

--- a/_plugins/sheafy.rb
+++ b/_plugins/sheafy.rb
@@ -4,12 +4,12 @@ module Sheafy
   def self.render_header(resource, level)
     slug = resource.data["slug"]
     title = resource.data["title"]
-    breadcrumb = resource.data["breadcrumb"]
+    numbering = resource.data["numbering"]
     href = "{{ '#{resource.url}' | relative_url }}"
 
     <<~HEADER
       <h#{level} id="#{slug}">
-        #{breadcrumb} #{title}
+        #{numbering} #{title}
         <a class="slug" href="#{href}">[#{slug}]</a>
       </h#{level}>
 
@@ -88,9 +88,9 @@ module Sheafy
     tsorted_nodes.reverse.each do |node|
       parent = node.data["parents"].first
       unless parent.nil?
-        parent.data["breadcrumb"] ||= ""
+        parent.data["numbering"] ||= ""
         index = 1 + parent.data["children"]&.index(node) || 0
-        node.data["breadcrumb"] = "#{parent.data["breadcrumb"]}#{index}."
+        node.data["numbering"] = "#{parent.data["numbering"]}#{index}."
       end
     end
 

--- a/assets/style.scss
+++ b/assets/style.scss
@@ -67,3 +67,7 @@ ul.toc {
 div.bibtex-code {
   margin-top: 1em;
 }
+
+header.post-header {
+  margin-bottom: 1em !important;
+}


### PR DESCRIPTION
As in the Stacks Project, it is useful to display human-readable (but potentially unstable) section indices in addition to the stable node identifiers/tags. I wasn't sure if this is necessarily the best way to implement this feature, so feel free to tear it apart 😄 