### PR TITLE
feat: #33 authorship in changelog

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -100,9 +100,8 @@ defaults:
 changelog:
   authors:
     jon@jonmsterling.com:
-      name: Jon Sterling
       link: https://www.jonmsterling.com/
     carlo@carloangiuli.com:
-      name: Carlo Angiuli
       link: http://www.cs.cmu.edu/~cangiuli/
-    paolo.brasolin@gmail.com: null
+    paolo.brasolin@gmail.com:
+      hide: true

--- a/_config.yml
+++ b/_config.yml
@@ -96,3 +96,13 @@ defaults:
     values:
       layout: node
       excerpt: ""
+
+changelog:
+  authors:
+    jon@jonmsterling.com:
+      name: Jon Sterling
+      link: https://www.jonmsterling.com/
+    carlo@carloangiuli.com:
+      name: Carlo Angiuli
+      link: http://www.cs.cmu.edu/~cangiuli/
+    paolo.brasolin@gmail.com: null

--- a/_plugins/changelog.rb
+++ b/_plugins/changelog.rb
@@ -10,7 +10,8 @@ module Changelog
     def generate(site)
       nodes = site.collections.values_at(*NODES_COLLECTIONS_NAMES).flat_map(&:docs)
       changelog = site.pages.find { |page| page.relative_path == CHANGELOG_PAGE_PATH }
-      commits = parse_git_data(get_git_data)
+      authors = site.config.fetch("changelog", {}).fetch("authors", {})
+      commits = parse_git_data(get_git_data, authors)
       commits.each do |commit|
         commit["diffs"].each do |diff|
           diff["node"] = nodes.find do |node|
@@ -25,7 +26,7 @@ module Changelog
       stdout, stderr, status = Open3.capture3(
         [
           "git log",
-          "--pretty='format:%H %at %s'",
+          "--pretty='format:%H %at %aE %s'",
           # we're interested in ADM of files (not Rs or Cs)
           "--name-status",
           "--no-renames",
@@ -38,16 +39,17 @@ module Changelog
       stdout
     end
 
-    def parse_git_data(data)
+    def parse_git_data(data, authors)
       [].tap do |changelog|
         data.split("\n\n").each do |block|
           commit, *diff = block.split("\n")
-          hash, timestamp, subject = commit.split(' ', limit=3)
+          hash, timestamp, email, subject = commit.split(' ', limit=4)
           changelog << {
             "hash" => hash,
             "timestamp" => Time.at(timestamp.to_i),
             "subject" => subject,
             "diffs" => [],
+            "author" => authors[email]
           }
           diff.each do |line|
             status, path = line.split("\t")

--- a/_plugins/changelog.rb
+++ b/_plugins/changelog.rb
@@ -1,5 +1,6 @@
 require 'open3'
 require 'date'
+require 'byebug'
 
 module Changelog
   class Generator < Jekyll::Generator
@@ -26,7 +27,7 @@ module Changelog
       stdout, stderr, status = Open3.capture3(
         [
           "git log",
-          "--pretty='format:%H %at %aE %s'",
+          "--pretty='format:#{%w{%H %at %aN %aE %s}.join('%x00')}'",
           # we're interested in ADM of files (not Rs or Cs)
           "--name-status",
           "--no-renames",
@@ -43,13 +44,16 @@ module Changelog
       [].tap do |changelog|
         data.split("\n\n").each do |block|
           commit, *diff = block.split("\n")
-          hash, timestamp, email, subject = commit.split(' ', limit=4)
+          hash, timestamp, name, mail, subject = commit.split("\u0000")
           changelog << {
             "hash" => hash,
             "timestamp" => Time.at(timestamp.to_i),
             "subject" => subject,
             "diffs" => [],
-            "author" => authors[email]
+            "author" => {
+              "name" => name,
+              "mail" => mail,
+            }.merge(authors.fetch(mail, {})),
           }
           diff.each do |line|
             status, path = line.split("\t")

--- a/changelog.md
+++ b/changelog.md
@@ -43,6 +43,11 @@ limit: 30
   li.diff-M::marker { color: hsl(240, 100%, 40%); }
   li.diff-D::marker { color: hsl(  0, 100%, 40%); }
 
+  .author {
+    float: right;
+    font-style: italic;
+  }
+
 </style>
 
 {% if page.commits.size > page.limit %}
@@ -63,15 +68,15 @@ These are the last {{ page.limit }} of the {{ page.commits.size }} commits invol
 
 {{ commit.subject }}
 
-{{ if commit.author -}}
-  <span style="float:right;display:box;">
-    {%- if commit.author.link -%}
+{% unless commit.author.hide -%}
+  <span class="author">by
+    {% if commit.author.link -%}
       <a href="{{ commit.author.link }}">{{ commit.author.name }}</a>
     {%- else -%}
       {{ commit.author.name }}
     {%- endif -%}
   </span>
-{{- endif }}
+{%- endunless %}
 
 </dt>
 

--- a/changelog.md
+++ b/changelog.md
@@ -63,6 +63,16 @@ These are the last {{ page.limit }} of the {{ page.commits.size }} commits invol
 
 {{ commit.subject }}
 
+{{ if commit.author -}}
+  <span style="float:right;display:box;">
+    {%- if commit.author.link -%}
+      <a href="{{ commit.author.link }}">{{ commit.author.name }}</a>
+    {%- else -%}
+      {{ commit.author.name }}
+    {%- endif -%}
+  </span>
+{{- endif }}
+
 </dt>
 
 <dd>


### PR DESCRIPTION
This might look like overkill, but it allows to:
* simplify parsing the git log
* aggregate multiple emails under the same name (w/o `.mailmap` which btw works anyways)
* omit a given author (e.g. me, as I'm not writing math but doing maintenance)
* provide (or omit) custom links for each author

Since the theme is using attribution to stimulate attribution, I think all this is pretty much necessary.

Downside: you need to add authors to the `_config.yml`.
I guess that's okay until there are too many, though.

Let me know what you think!