### PR TITLE
Support for cleveref-style refs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'minima', '~> 2.0'
 group :jekyll_plugins do
   gem 'jekyll-antex', '~> 0.6.1'
   gem 'jekyll-scholar'
-  gem 'jekyll-sheafy', github: 'paolobrasolin/jekyll-sheafy', branch: 'main'
+  gem 'jekyll-sheafy', github: 'jonsterling/jekyll-sheafy', branch: 'pref-and-cref'
 end
 
 # kramdown v2 ships without the gfm parser by default. If you're using

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
-  remote: https://github.com/paolobrasolin/jekyll-sheafy.git
-  revision: 78ff488c3ac2a2ad560bb6109c3fc4415d63bec3
-  branch: main
+  remote: https://github.com/jonsterling/jekyll-sheafy.git
+  revision: 8d71f5d2656abf01fc2281d362ced7d2c63fac7d
+  branch: pref-and-cref
   specs:
     jekyll-sheafy (0.1.0)
       jekyll (>= 3, < 5)

--- a/_config.yml
+++ b/_config.yml
@@ -149,6 +149,7 @@ sheafy:
       sublayout: sheafy/node/result
       genus: Remark
       clicker: result
+
 changelog:
   authors:
     jon@jonmsterling.com:

--- a/_includes/list.html
+++ b/_includes/list.html
@@ -3,10 +3,7 @@
   {% for resource in sorted_resources %}
   <li>
     <a href="{{resource.url | relative_url}}">
-      {% if resource.collection == "nodes" %}
-      <span class="numbering">{{ resource.clicks | to_numbering }}.</span>
-      {% endif %}
-      {{resource.title}}
+      {{ resource | display_title }}
       {% if resource.collection == "nodes" %}
       <span class="slug">[{{resource.slug}}]</span>
       {% endif %}

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -4,13 +4,7 @@
   <li>
     {{ resource.clicks | to_numbering }}.
     <a href="#{{resource.slug}}">
-      {%- if resource.title != resource.slug -%}
-        {{ resource.title }}
-      {%- elsif resource.genus -%}
-        {{ resource.genus }}
-      {%- else -%}
-        {{ resource.slug }}
-      {%- endif -%}
+      {{ resource.title }}
     </a>
     <a class="slug" href="{{resource.url | relative_url}}">[{{resource.slug}}]</a>
     {% include toc.html page=resource %}

--- a/_layouts/sheafy/node/result.md
+++ b/_layouts/sheafy/node/result.md
@@ -4,12 +4,7 @@
 
 <header class="inline" id="{{ page.slug }}">
   <a class="slug" href="{{ page.url | relative_url }}">[{{ page.slug }}]</a>
-  <strong>{{ page.genus | default: 'Result' }} <span class="numbering">{{-page.clicks | to_numbering-}}</span></strong>
-  {%- assign downslug = page.slug | downcase-%}
-  {%- assign downtitle = page.title | downcase-%}
-  {%- if downslug != downtitle %}
-  ({{ page.title }})
-  {%-endif-%}.
+  {{page | display_title_parenthetical -}}.
 </header>
 
 {:/}

--- a/_nodes/0002.md
+++ b/_nodes/0002.md
@@ -7,7 +7,7 @@ taxon: definition
 A displayed category $E$ over $B$ is said to be a *cartesian fibration*, when
 for each morphism $f : x \to y$ and displayed object $\bar{y}\in E\Sub{y}$, there
 exists a displayed object $\bar{x}\in E\Sub{x}$ and a *cartesian* morphism
-$\bar{f} : \bar{x}\to\Sub{f} \bar{y}$ in the sense of {%ref 0001%}. Note that the pair $(\bar{x},\bar{f})$ is unique up to
+$\bar{f} : \bar{x}\to\Sub{f} \bar{y}$ in the sense of {%cref 0001%}. Note that the pair $(\bar{x},\bar{f})$ is unique up to
 unique isomorphism, so being a cartesian fibration is a *property* of a displayed category.
 
 There are other variations of fibration. For instance, $E$ is said to be an

--- a/_nodes/000D.md
+++ b/_nodes/000D.md
@@ -14,7 +14,7 @@ displayed category $B\Sub{!}F$ over $B$ as follows:
 1. An object of $(B\Sub{!}F)\Sub{x}$ is a pair $(\bar{x},{\ddot{x}})$ with $\bar{x}\in E\Sub{x}$ and ${\ddot{x}}\in F\Sub{\bar{x}}$.
 2. A morphism $(\bar{x},{\ddot{x}})\to\Sub{f}(\bar{y},{\ddot{y}})$ is given by a pair $(\bar{f},{\ddot{f}})$ where $\bar{f}:\bar{x}\to\Sub{f}\bar{y}$ in $E$ and ${\ddot{f}}:{\ddot{x}}\to\Sub{\bar{f}} {\ddot{y}}$ in $F$.
 
-By virtue of {%ref 000B%}, we may define the *pushforward* of a displayed category along a functor. In particular, let $E$
+By virtue of {%cref 000B%}, we may define the *pushforward* of a displayed category along a functor. In particular, let $E$
 be displayed over $B$ and let $U:B\to C$ be an ordinary functor; then we may
 obtain a displayed category $U\Sub{!}E$ over $C$ as follows:
 
@@ -24,6 +24,6 @@ obtain a displayed category $U\Sub{!}E$ over $C$ as follows:
    $\TotCat{U\Sub{\bullet}}\to B$.
 3. Because $E$ is displayed over $B$, we may regard it as displayed over the
    equivalent total category $\TotCat{U\Sub{\bullet}}$ by
-   change of base {%ref 0007%}.
+   change of base {%pref 0007%}.
 4. Hence we may define the pushforward $U\Sub{!}E$ to be the displayed category $(U\Sub{\bullet})\Sub{!}E$ as defined above.
 

--- a/_nodes/000G.md
+++ b/_nodes/000G.md
@@ -5,7 +5,7 @@ macrolib: topos
 
 An ordinary category $E$ is called *locally small* when for any $x,y\in E$ the
 collection of morphisms $x\to y$ is a set.  This property of $E$ can be
-rephrased in terms of its *family fibration* {% ref 0006 %} $\FAM{E}$ over
+rephrased in terms of its *family fibration* {% pref 0006 %} $\FAM{E}$ over
 $\SET$ as follows.
 
 Consider an index set $I\in \SET$ and two families $u,v\in C^I$. We may define

--- a/_nodes/000H.md
+++ b/_nodes/000H.md
@@ -6,7 +6,7 @@ macrolib: topos
 We will reformulate the above in a way that uses only the language that makes
 sense for an arbitrary cartesian fibration, though for now we stick with $\FAM{C}$. Given
 $u,v\in \FAM{C}[I]$, we have a "relative hom family" $[u,v]\in\Sl{\SET}{I}$,
-defined in {%ref 000G%}. The fact that each $[u,v]\Sub{i}$ is the set of all
+defined in {%cref 000G%}. The fact that each $[u,v]\Sub{i}$ is the set of all
 morphisms $u\Sub{i}\to v\Sub{i}$ can be rephrased more abstractly.
 
 First we consider the restriction of $u\in \FAM{C}[I]$ to $\FAM{C}[[u,v]]$ as follows:

--- a/_nodes/000L.md
+++ b/_nodes/000L.md
@@ -27,7 +27,7 @@ consider the cartesian map displayed over $z : I \to C$:
 
 Conversely assume that $\FAM{C}$ has a generic object $\bar{u}\in\FAM{C}[U]$
 for some $U\in \SET$; then we may equip $U$ with the structure of a globally
-small category such that $U$ is equivalent to $C$, using a construction that is similar to our implementation of the opposite fibration {%ref 000Q%}. In particular we define a
+small category such that $U$ is equivalent to $C$, using a construction that is similar to our implementation of the opposite fibration {%pref 000Q%}. In particular we define a
 morphism $x\to y\in U$ to be given by the following data:
 
 1. a cartesian map $a\to\Sub{x} \bar{u}$ over $x : 1\to U$,

--- a/_nodes/000N.md
+++ b/_nodes/000N.md
@@ -10,7 +10,7 @@ to $\SET$ (i.e. small categories) and their family fibrations over $\SET$.
 
 @include{001Q}
 
-We have already seen in {%ref 000G%} and {%ref 000L%} that smallness in the
+We have already seen in {%cref 000G%} and {%cref 000L%} that smallness in the
 sense of the definition above appropriately generalizes the ordinary notion of
 smallness for categories over $\SET$. Another perspective on smallness is given
 by the *internal language*, in which a category is viewed as an algebra for the

--- a/_nodes/000S.md
+++ b/_nodes/000S.md
@@ -3,7 +3,7 @@ title: Exegesis of opposite categories
 macrolib: topos
 ---
 
-The construction of fibered opposite categories {%ref 000Q%} does appear quite
+The construction of fibered opposite categories {%pref 001Z%} does appear quite
 involved, but it can be seen to be inevitable from the perspective of the fiber
 categories $\OpCat{E}\Sub{x}$ {%ref 0005%}. Indeed, let $u,v\in
 \OpCat{E}\Sub{x}$ and fix a *vertical* map $h : u \to v\in \OpCat{E}\Sub{x}$;

--- a/_nodes/000U.md
+++ b/_nodes/000U.md
@@ -3,7 +3,7 @@ title: Cartesian lifts in the opposite category
 macrolib: topos
 ---
 
-The foregoing characterization {%ref 000T%} of cartesian maps in $\OpCat{E}$
+The foregoing characterization of cartesian maps in $\OpCat{E}$
 immediately implies that $\OpCat{E}$ is fibered over $B$.
 
 @include{0021}

--- a/_nodes/000Z.md
+++ b/_nodes/000Z.md
@@ -3,14 +3,14 @@ title: The internalization of a small fibration
 macrolib: topos
 ---
 
-Let $C$ be a small cartesian fibration {%ref 001Q %} over $B$ a category with finite
-limits, i.e. a cartesian fibration that is both locally small {%ref 000I%} and globally
-small {%ref 000P%}. We will show that $C$ is equivalent to the externalization
+Let $C$ be a small cartesian fibration {%pref 001Q %} over $B$ a category with finite
+limits, i.e. a cartesian fibration that is both locally small {%pref 001B%} and globally
+small {%pref 000P%}. We will show that $C$ is equivalent to the externalization
 {%ref 000V%} of an internal category {%ref 000O%} $\underline{C}$ in $B$,
 namely the full internal subcategory {%ref 0011%} associated to the generic
 object $\bar{u}\in C$.
 
-By {%ref 0011%} we know that the externalization of $\underline{C}$ so-defined
+By {%cref 001S%} we know that the externalization of $\underline{C}$ so-defined
 is equivalent to the full subfibration $\FullSubfib{\bar{u}}$ of $C$ spanned by
 objects that are "classified" by $\bar{u}$. Because $\bar{u}$ is generic, we
 know that *every* object of $C$ is classified by $\bar{u}$, so we are done.

--- a/_nodes/0011.md
+++ b/_nodes/0011.md
@@ -3,7 +3,7 @@ title: The full internal subcategory associated to a displayed object
 macrolib: topos
 ---
 
-This full internal subfibration {%ref 0010%} associated to a displayed object $\bar{u}$ of a locally small cartesian fibration $E$ over $B$ can be seen to be equivalent to the externalization
+The full internal subfibration {%pref 0010%} associated to a displayed object $\bar{u}$ of a locally small cartesian fibration $E$ over $B$ can be seen to be equivalent to the externalization
 of an internal category $\gl{\bar{u}}$ in $B$. In particular, we let the object of objects $\gl{\bar{u}}\Sub{0}$ be $u$ itself; defining the object of arrows $\gl{\bar{u}}\Sub{1}$ is more complex, making critical use of the local smalness of $E$ over $B$.
 
 We will think of the fiber $E\Sub{u\times u}$ as the category of

--- a/_nodes/0013.md
+++ b/_nodes/0013.md
@@ -5,7 +5,7 @@ macrolib: topos
 
 @include{001O}
 
-Recall from {%ref 0005 %} that for every $b\in B$, the collection of displayed
+Recall from {%cref 0005 %} that for every $b\in B$, the collection of displayed
 objects $E\Sub{b}$ and vertical maps $E\Sub{1\Sub{b}}$ forms a category. When $E$ is
 a right fibration over $B$, this category is in fact a *groupoid*.
 

--- a/_nodes/0016.md
+++ b/_nodes/0016.md
@@ -32,4 +32,4 @@ $\bar{m} : \bar{y}\to\Sub{m} \bar{u}$ with $\bar{f};\bar{m} = \bar{h}$:
 »
 
 We use a "pushout corner" to indicate $\bar{x}\to\bar{y}$ as a cocartesian morphism,
-a notation justified by {%ref 0019 %}.
+a notation justified by {%cref 0019 %}.

--- a/_nodes/0019.md
+++ b/_nodes/0019.md
@@ -3,7 +3,7 @@ title: "Example: Coslices and pushouts"
 macrolib: topos
 ---
 
-Dually to {%ref 0003 %}, every category $B$ can also be displayed over itself via its
+Dually to {%cref 0003 %}, every category $B$ can also be displayed over itself via its
 *coslices*. That is, for any category $B$, we define a displayed category
 $\overline{B}$ over $B$ as follows:
 1. For $x\in B$, define $\overline{B}\Sub{x}$ as the collection of pairs

--- a/_nodes/001J.md
+++ b/_nodes/001J.md
@@ -3,6 +3,6 @@ macrolib: topos
 taxon: exercise
 ---
 
-Let $E$ be displayed over $B$. Prove that the total category {%ref 000A %}
+Let $E$ be displayed over $B$. Prove that the total category {%pref 000A %}
 $\TotCat{\TotOpCat{E}}$ is $\OpCat{\prn{\TotCat{E}}}$, and its projection functor is
 $\OpCat{\prn{p\Sub{E}}} : \OpCat{\TotCat{E}}\to\OpCat{B}$.

--- a/_nodes/001N.md
+++ b/_nodes/001N.md
@@ -3,5 +3,5 @@ taxon: exercise
 macrolib: topos
 ---
 
-Prove that the total category {%ref 000A%} of $\overline{B}$ is the
+Prove that the total category {%cref 000A%} of $\overline{B}$ is the
 arrow category $B^{\to}$, and the projection is the *domain* functor.

--- a/_nodes/001T.md
+++ b/_nodes/001T.md
@@ -3,5 +3,5 @@ taxon: exercise
 macrolib: topos
 ---
 
-Prove that the total category $\TotCat{\SelfIx{B}}$ of the canonical self-indexing {%ref 0003%} is the arrow category $B^{\to}$, and the projection is the codomain functor.
+Prove that the total category $\TotCat{\SelfIx{B}}$ of the canonical self-indexing {%pref 0003%} is the arrow category $B^{\to}$, and the projection is the codomain functor.
 

--- a/_nodes/0029.md
+++ b/_nodes/0029.md
@@ -19,7 +19,7 @@ category, hypocartesian morphisms may not be closed under composition.
 Grothendieck {%cite sga:1 -A%} defines a fibration in terms of (what we refer
 to as) hypocartesian morphisms rather than (what we refer to as) cartesian
 morphisms, and therefore imposes the additional constraint that the
-hypocartesian morphisms be closed under composition. In {%ref 002C%} below, we
+hypocartesian morphisms be closed under composition. In {%cref 002B %} below, we
 verify that these two definitions of cartesian fibration coincide.
 
 @include{002B}

--- a/_nodes/002B.md
+++ b/_nodes/002B.md
@@ -1,11 +1,11 @@
 ---
 taxon: lemma
 macrolib: topos
-title: Equivalence with Grothendieck's fibrations
+title: "Equivalence with Grothendieck's fibrations"
 ---
 
 Let $E$ be displayed over $B$. Then $E$ is a cartesian fibration in the sense of
-{%ref 0002%} if and only if the following two conditions hold:
+{%cref 0002%} if and only if the following two conditions hold:
 
 1. *Hypocartesian lifts.* For each $f:x\to y\in B$ and $\bar{y}\in E\Sub{y}$ there
    exists a displayed object $\bar{x}\in E\Sub{x}$ and hypocartesian morphism
@@ -16,9 +16,8 @@ Let $E$ be displayed over $B$. Then $E$ is a cartesian fibration in the sense of
 
 **Proof.** Suppose first that $E$ is a cartesian fibration in our sense. Then
 $E$ has hypocartesian lifts because it has cartesian lifts. For closure under
-composition, fix hypocartesian $\bar{f},\bar{g}$; by {%ref 002C%} we know that
-$\bar{f},\bar{g}$ are also cartesian and hence by the generalized pullback
-lemma {%ref 001H%} so is the composite $\bar{f};\bar{g}$; therefore it follows
+composition, fix hypocartesian $\bar{f},\bar{g}$; by {%cref 002C%} we know that
+$\bar{f},\bar{g}$ are also cartesian and hence by {%cref 001H%} so is the composite $\bar{f};\bar{g}$; therefore it follows
 that $\bar{f};\bar{g}$ is also hypocartesian.
 
 Conversely, suppose that $E$ is a cartesian fibration in the sense of

--- a/_nodes/002C.md
+++ b/_nodes/002C.md
@@ -4,7 +4,7 @@ macrolib: topos
 title: Hypocartesian = cartesian in a cartesian fibration
 ---
 
-Let $E$ be a cartesian fibration in the sense of {%ref 0002%}, and let
+Let $E$ be a cartesian fibration in the sense of {%cref 0002%}, and let
 $\bar{f} : \bar{x}\to\Sub{f}\bar{y}$ be displayed over $f:x\to y$. The
 displayed morphism $\bar{f}$ is cartesian if and only if it is hypocartesian.
 

--- a/_nodes/002D.md
+++ b/_nodes/002D.md
@@ -9,8 +9,8 @@ of as two distinct ways to generalize the concept of a pullback, depending on
 what one considers the essential properties of pullbacks. Hypocartesian
 morphisms more directly generalize the "little picture" universal property of
 pullbacks as limiting cones, whereas cartesian morphisms generalize the "big
-picture" dynamics of the pullback pasting lemma. As we have seen in {%ref
+picture" dynamics of the pullback pasting lemma. As we have seen in {%cref
 002C%} these two notions coincide in any cartesian fibration; the instance of
-this result for the canonical self-indexing {%ref 001X%} verifies that
+this result for the canonical self-indexing {%pref 001X%} verifies that
 pullbacks can be equivalently presented in terms of cartesian morphisms, as we
-have pointed out in {%ref 001Y%}.
+have pointed out in {%cref 001Y%}.

--- a/_plugins/display_title_filter.rb
+++ b/_plugins/display_title_filter.rb
@@ -1,0 +1,22 @@
+module DisplayTitleFilter
+  extend self
+
+  def display_index(resource)
+    info = NodeInfo.new resource
+    info.display_index
+  end
+
+  def display_title(resource)
+    info = NodeInfo.new resource
+    info.display_title
+  end
+
+  def display_title_parenthetical(resource)
+    info = NodeInfo.new resource
+    info.display_title_parenthetical
+  end
+
+end
+
+Liquid::Template.register_filter(DisplayTitleFilter)
+

--- a/_plugins/node_info.rb
+++ b/_plugins/node_info.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'cgi'
 
 class NodeInfo
   def initialize(resource)
@@ -34,27 +35,16 @@ class NodeInfo
   end
 
   def display_title
-    if taxon.nil? then
-      title
-    else
-      display_index + (has_title? ? ". #{title}" : "")
-    end
+    taxon.nil? ? title : (display_index + (has_title? ? ". #{title}" : ""))
   end
 
   def display_title_parenthetical
-    if taxon.nil? then
-      title
-    else
-      display_index + (has_title? ? " (#{title})" : "")
-    end
+    taxon.nil? ? title : (display_index + (has_title? ? " (#{title})" : ""))
   end
 
   def aria_label
-    if taxon.nil? then
-      title
-    else
-      "#{genus} #{ToNumberingFilter.to_numbering @node['clicks']}." + (has_title? ? " #{title}" : "")
-    end
+    label = taxon.nil? ? title : ("#{genus} #{ToNumberingFilter.to_numbering @node['clicks']}." + (has_title? ? " #{title}" : ""))
+    CGI.escapeHTML label
   end
 end
 

--- a/_plugins/node_info.rb
+++ b/_plugins/node_info.rb
@@ -31,7 +31,7 @@ class NodeInfo
   end
 
   def display_index
-    "<span class='numbering'>#{genus} #{ToNumberingFilter.to_numbering @node['clicks']}</span>"
+    "<span class='numbering'>#{genus} #{clicks_to_numbering @node['clicks']}</span>"
   end
 
   def display_title
@@ -43,7 +43,7 @@ class NodeInfo
   end
 
   def aria_label
-    label = taxon.nil? ? title : ("#{genus} #{ToNumberingFilter.to_numbering @node['clicks']}." + (has_title? ? " #{title}" : ""))
+    label = taxon.nil? ? title : ("#{genus} #{clicks_to_numbering @node['clicks']}." + (has_title? ? " #{title}" : ""))
     CGI.escapeHTML label
   end
 end

--- a/_plugins/node_info.rb
+++ b/_plugins/node_info.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+class NodeInfo
+  def initialize(resource)
+    @node = resource
+  end
+
+  def title
+    @node["title"]
+  end
+
+  def slug
+    @node["slug"]
+  end
+
+  def has_title?
+    title != slug.downcase
+  end
+
+  def taxon
+    @node["taxon"]
+  end
+
+  def genus
+    if taxon == "section" then
+      "Section"
+    else
+      @node["genus"] || "Result"
+    end
+  end
+
+  def display_index
+    "<span class='numbering'>#{genus} #{ToNumberingFilter.to_numbering @node['clicks']}</span>"
+  end
+
+  def display_title
+    if taxon.nil? then
+      title
+    else
+      display_index + (has_title? ? ". #{title}" : "")
+    end
+  end
+
+  def display_title_parenthetical
+    if taxon.nil? then
+      title
+    else
+      display_index + (has_title? ? " (#{title})" : "")
+    end
+  end
+
+  def aria_label
+    if taxon.nil? then
+      title
+    else
+      "#{genus} #{ToNumberingFilter.to_numbering @node['clicks']}." + (has_title? ? " #{title}" : "")
+    end
+  end
+end
+
+

--- a/_plugins/node_info.rb
+++ b/_plugins/node_info.rb
@@ -14,6 +14,7 @@ class NodeInfo
     @node["slug"]
   end
 
+  # This is a very strange routine, but at least the logic is factored out here.
   def has_title?
     title != slug.downcase
   end

--- a/_plugins/ref_tag.rb
+++ b/_plugins/ref_tag.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
-
-# A tag to generate a [XXXXX] reference link to a node
+#
 class RefTag < Liquid::Tag
   def initialize(tag_name, slug, tokens)
     super
@@ -11,10 +10,42 @@ class RefTag < Liquid::Tag
     registers = context.registers
     site = registers[:site]
     node = site.collections['nodes'].docs.detect { |doc| doc.data['slug'] == @slug }
-    "<a href='#{site.baseurl}#{node.url}' role='tooltip' aria-label='#{node.data["title"]}' class='slug'>[#{@slug}]</a>"
+    info = NodeInfo.new node.data
+    "<a href='#{site.baseurl}#{node.url}' role='tooltip' aria-label='#{info.aria_label}' class='slug'>[#{@slug}]</a>"
   end
 end
 
+class CleverRefTag < Liquid::Tag
+  def initialize(tag_name, slug, tokens)
+    super
+    @slug = slug.strip
+  end
+
+  def render(context)
+    registers = context.registers
+    site = registers[:site]
+    node = site.collections['nodes'].docs.detect { |doc| doc.data['slug'] == @slug }
+    info = NodeInfo.new node.data
+    "<a href='#{site.baseurl}#{node.url}' role='tooltip' aria-label='#{info.aria_label}' class='cref'>#{info.display_index} <span class='slug'>[#{@slug}]</span></a>"
+  end
+end
+
+class ParenCleverRefTag < Liquid::Tag
+  def initialize(tag_name, slug, tokens)
+    super
+    @slug = slug.strip
+  end
+
+  def render(context)
+    registers = context.registers
+    site = registers[:site]
+    node = site.collections['nodes'].docs.detect { |doc| doc.data['slug'] == @slug }
+    info = NodeInfo.new node.data
+    "(<a href='#{site.baseurl}#{node.url}' role='tooltip' aria-label='#{info.aria_label}' class='cref'>#{info.display_index} <span class='slug'>[#{@slug}]</span></a>)"
+  end
+end
+
+
 Liquid::Template.register_tag('ref', RefTag)
-Liquid::Template.register_tag('cref', RefTag)
-Liquid::Template.register_tag('pref', RefTag)
+Liquid::Template.register_tag('cref', CleverRefTag)
+Liquid::Template.register_tag('pref', ParenCleverRefTag)

--- a/_plugins/ref_tag.rb
+++ b/_plugins/ref_tag.rb
@@ -16,3 +16,5 @@ class RefTag < Liquid::Tag
 end
 
 Liquid::Template.register_tag('ref', RefTag)
+Liquid::Template.register_tag('cref', RefTag)
+Liquid::Template.register_tag('pref', RefTag)

--- a/_plugins/to_numbering_filter.rb
+++ b/_plugins/to_numbering_filter.rb
@@ -1,16 +1,19 @@
-module ToNumberingFilter
-  extend self
-  def to_numbering(clicks)
-    label = ""
-    # NOTE: we skip the first one because it's the lesson
-    clicks[1..].each do |tick|
-      label << case tick["clicker"]
-        when "section" then ".#{tick["value"] + 1}"
-        when "result" then "·#{(tick["value"] + 97).chr}"
-        else ".#{tick["value"]}"
-      end
+def clicks_to_numbering(clicks)
+  label = ""
+  # NOTE: we skip the first one because it's the lesson
+  clicks[1..].each do |tick|
+    label << case tick["clicker"]
+    when "section" then ".#{tick["value"] + 1}"
+    when "result" then "·#{(tick["value"] + 97).chr}"
+    else ".#{tick["value"]}"
     end
-    label[1..]
+  end
+  label[1..]
+end
+
+module ToNumberingFilter
+  def to_numbering(clicks)
+    clicks_to_numbering clicks
   end
 end
 

--- a/_plugins/to_numbering_filter.rb
+++ b/_plugins/to_numbering_filter.rb
@@ -1,4 +1,5 @@
 module ToNumberingFilter
+  extend self
   def to_numbering(clicks)
     label = ""
     # NOTE: we skip the first one because it's the lesson

--- a/assets/style.scss
+++ b/assets/style.scss
@@ -77,3 +77,7 @@ header.inline {
   display: inline;
   margin-right: 1ex;
 }
+
+header.inline .numbering {
+  font-weight: bold;
+}


### PR DESCRIPTION
I have added support for `cref` and `pref` tag, that produce links `Definition 1.4*a [000X]` and `(Definition 1.5*a [000X])` respectively.

I also refactored the code that produces the long-names of nodes. My code may need some further changes in order to match the Ruby idiom, so please feel free to tear it apart. My motivations were in part to address some of the oddities caused by #38.