### PR TITLE
chore: bump jekyll-sheafy and jekyll-antex

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,9 +8,9 @@ gem 'jekyll', '~> 4.2.1'
 gem 'minima', '~> 2.0'
 
 group :jekyll_plugins do
-  gem 'jekyll-antex', '~> 0.6.1'
+  gem 'jekyll-antex', '~> 0.7.0'
   gem 'jekyll-scholar'
-  gem 'jekyll-sheafy', github: 'jonsterling/jekyll-sheafy', branch: 'pref-and-cref'
+  gem 'jekyll-sheafy', '~> 0.2.0'
 end
 
 # kramdown v2 ships without the gfm parser by default. If you're using

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/jonsterling/jekyll-sheafy.git
-  revision: 8d71f5d2656abf01fc2281d362ced7d2c63fac7d
-  branch: pref-and-cref
-  specs:
-    jekyll-sheafy (0.1.0)
-      jekyll (>= 3, < 5)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -52,7 +44,7 @@ GEM
       rouge (~> 3.0)
       safe_yaml (~> 1.0)
       terminal-table (~> 2.0)
-    jekyll-antex (0.6.1)
+    jekyll-antex (0.7.0)
       antex (~> 0.1.3)
       jekyll (>= 3, < 5)
       kramdown-parser-gfm (~> 1.1.0)
@@ -67,6 +59,8 @@ GEM
       jekyll (~> 4.0)
     jekyll-seo-tag (2.7.1)
       jekyll (>= 3.8, < 5.0)
+    jekyll-sheafy (0.2.0)
+      jekyll (>= 3, < 5)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     kramdown (2.3.1)
@@ -109,9 +103,9 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (~> 4.2.1)
-  jekyll-antex (~> 0.6.1)
+  jekyll-antex (~> 0.7.0)
   jekyll-scholar
-  jekyll-sheafy!
+  jekyll-sheafy (~> 0.2.0)
   kramdown-parser-gfm
   minima (~> 2.0)
 

--- a/_config.yml
+++ b/_config.yml
@@ -99,6 +99,9 @@ defaults:
       excerpt: ""
 
 sheafy:
+  references:
+    matchers:
+      - !ruby/regexp /{%\s*[cp]?ref (?<slug>.+?)\s*%}/
   taxa:
     section:
       layout: sheafy/tree/default


### PR DESCRIPTION
I'm done with https://github.com/paolobrasolin/jekyll-sheafy/issues/4!

I just released `jekyll-sheafy` 0.2.0 (to fix that) and `jekyll-antex` 0.7.0 (to fix a bug not affecting you) so I'm bumping both.