### PR TITLE
fix rendering of result headers and first paragraph

### DIFF
--- a/assets/style.scss
+++ b/assets/style.scss
@@ -73,9 +73,12 @@ header.post-header {
 }
 
 header.inline {
-  float: left;
   display: inline;
-  margin-right: 1ex;
+  margin-right: .5ex;
+}
+
+header.inline + p {
+  display: inline;
 }
 
 header.inline .numbering {


### PR DESCRIPTION
It is very subtle to get a header to run into a paragraph correctly; the prior solution resulted in some misalignment at different screen sizes. The new solution is to get rid of `float:left`, and set both the header and the immediately-subsequent paragraph to be `display:inline`.

Here's how it looks now on a small screen: 
<img width="355" alt="image" src="https://user-images.githubusercontent.com/55057/151694910-678edad0-b965-491f-b7b3-3d850427aba7.png">
