### PR TITLE
Bump sheafy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'minima', '~> 2.0'
 group :jekyll_plugins do
   gem 'jekyll-antex', '~> 0.7.0'
   gem 'jekyll-scholar'
-  gem 'jekyll-sheafy', '~> 0.2.0'
+  gem 'jekyll-sheafy', '~> 0.3.0'
 end
 
 # kramdown v2 ships without the gfm parser by default. If you're using

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,7 @@ GEM
       jekyll (~> 4.0)
     jekyll-seo-tag (2.7.1)
       jekyll (>= 3.8, < 5.0)
-    jekyll-sheafy (0.2.0)
+    jekyll-sheafy (0.3.0)
       jekyll (>= 3, < 5)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
@@ -105,7 +105,7 @@ DEPENDENCIES
   jekyll (~> 4.2.1)
   jekyll-antex (~> 0.7.0)
   jekyll-scholar
-  jekyll-sheafy (~> 0.2.0)
+  jekyll-sheafy (~> 0.3.0)
   kramdown-parser-gfm
   minima (~> 2.0)
 

--- a/_config.yml
+++ b/_config.yml
@@ -90,17 +90,17 @@ defaults:
   - scope:
       type: nodes
     values:
-      macrolib: topos
       taxon: section
       excerpt: ""
   - scope:
       type: lectures
     values:
-      macrolib: topos
       taxon: section
       excerpt: ""
 
 sheafy:
+  inheritable:
+    - macrolib
   references:
     matchers:
       - !ruby/regexp /{%\s*[cp]?ref (?<slug>.+?)\s*%}/

--- a/_includes/d-pad.html
+++ b/_includes/d-pad.html
@@ -5,6 +5,24 @@
     justify-content: space-between;
     margin: 3rem 0rem 4rem 0rem;
   }
+
+  nav.d-pad i.arrow {
+    display: inline-block;
+    font-style: normal;
+    position: relative;
+    width: 0.4em;
+    height: 0.4em;
+    border: 0.2em solid black;
+    border-bottom: unset;
+  }
+  nav.d-pad i.arrow.left {
+    border-right: unset;
+    transform: rotate(-45deg);
+  }
+  nav.d-pad i.arrow.right {
+    border-left: unset;
+    transform: rotate(45deg);
+  }
 </style>
 
 <nav class="d-pad">
@@ -15,19 +33,17 @@
 
 {% if prev %}
   <a href="{{prev.url | relative_url}}">
-    <span class="left-arrow">⮜</span>
+    <i class="arrow left"></i>
     {{ prev | display_title }}
     <span class="slug">[{{prev.slug}}]</span>
   </a>
 {% endif %}
 
-<span>🙟</span>
-
 {% if next %}
   <a href="{{next.url | relative_url}}">
     {{ next | display_title }}
     <span class="slug">[{{next.slug}}]</span>
-    <span class="right-arrow">⮞</span>
+    <i class="arrow right"></i>
   </a>
 {% endif %}
 

--- a/_includes/d-pad.html
+++ b/_includes/d-pad.html
@@ -1,0 +1,36 @@
+<style>
+  nav.d-pad {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    margin: 3rem 0rem 4rem 0rem;
+  }
+</style>
+
+<nav class="d-pad">
+
+{% assign prev = page.predecessors | last %}
+{% assign upwd = page.parent %}
+{% assign next = page.successors | first %}
+
+{% if prev %}
+  <a href="{{prev.url | relative_url}}">
+    <span class="left-arrow">⮜</span>
+    <span class="numbering">{{ prev.clicks | to_numbering }}.</span>
+    {{prev.title}}
+    <span class="slug">[{{prev.slug}}]</span>
+  </a>
+{% endif %}
+
+<span>🙟</span>
+
+{% if next %}
+  <a href="{{next.url | relative_url}}">
+    <span class="numbering">{{ next.clicks | to_numbering }}.</span>
+    {{next.title}}
+    <span class="slug">[{{next.slug}}]</span>
+    <span class="right-arrow">⮞</span>
+  </a>
+{% endif %}
+
+</nav>

--- a/_includes/d-pad.html
+++ b/_includes/d-pad.html
@@ -16,8 +16,7 @@
 {% if prev %}
   <a href="{{prev.url | relative_url}}">
     <span class="left-arrow">⮜</span>
-    <span class="numbering">{{ prev.clicks | to_numbering }}.</span>
-    {{prev.title}}
+    {{ prev | display_title }}
     <span class="slug">[{{prev.slug}}]</span>
   </a>
 {% endif %}
@@ -26,8 +25,7 @@
 
 {% if next %}
   <a href="{{next.url | relative_url}}">
-    <span class="numbering">{{ next.clicks | to_numbering }}.</span>
-    {{next.title}}
+    {{ next | display_title }}
     <span class="slug">[{{next.slug}}]</span>
     <span class="right-arrow">⮞</span>
   </a>

--- a/_layouts/sheafy/tree/default.html
+++ b/_layouts/sheafy/tree/default.html
@@ -11,6 +11,8 @@ layout: default
     {{ content }}
   </div>
 
+  {% include d-pad.html page=page %}
+
   {% if page.referrers.size != 0 %}
   <nav>
     <h4>Referrers</h4>

--- a/_lectures/categorical-foundations.md
+++ b/_lectures/categorical-foundations.md
@@ -4,6 +4,7 @@ date: 2022-01-01
 author:
 - Jonathan Sterling
 - Carlo Angiuli
+macrolib: topos
 ---
 
 We assume knowledge of basic categorical concepts such as categories, functors,

--- a/_lectures/topos.md
+++ b/_lectures/topos.md
@@ -2,6 +2,7 @@
 title: Geometric universes and topoi (draft)
 date: 2022-01-08
 author: Jonathan Sterling
+macrolib: topos
 ---
 
 @include{0023}


### PR DESCRIPTION
I released `jekyll-sheafy` 0.3.0 which has [some new features](https://github.com/paolobrasolin/jekyll-sheafy/blob/main/CHANGELOG.md#030---2022-02-01) enabling the content of this PR:
* prev/next navigation (I sketched some buttons; they'll need more work for mobile)
* inheriting `macrolib` from the root node (i.e. the lecture, so you can have minibooks with separate macrosets in the same website as we discussed)