### PR TITLE
Search tool

### DIFF
--- a/_includes/custom-head.html
+++ b/_includes/custom-head.html
@@ -3,6 +3,9 @@
 <script defer src="https://cdn.jsdelivr.net/npm/katex@0.15.1/dist/contrib/auto-render.min.js" integrity="sha384-+XBljXPPiv+OzfbB3cVmLHf4hdUFHlWNZN5spNQ7rmHTXpd7WvJum6fIACpNNfIR" crossorigin="anonymous"></script>
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/microtip@0.2.2/microtip.min.css" integrity="sha256-RUSUTTyNeNKfP+mJISBiUTVElF6MSDsJcwYZrcSyUII=" crossorigin="anonymous">
+<script src="https://cdn.jsdelivr.net/npm/mark.js@8.11.1/dist/mark.min.js" integrity="sha256-IdYuEFP3WJ/mNlzM18Y20Xgav3h5pgXYzl8fW4GnuPo=" crossorigin="anonymous"></script>
+
+<script src="https://cdn.jsdelivr.net/npm/lunr@2.3.9/lunr.min.js" integrity="sha256-DFDZACuFeAqEKv/7Vnu1Tt5ALa58bcWZegGGFNgET8g=" crossorigin="anonymous"></script>
 
 <script>
   const macros_promise =

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -18,6 +18,7 @@
         </label>
 
         <div class="trigger">
+          <a class="page-link" id="search-toggle">Search</a>
           {%- for path in page_paths -%}
             {%- assign my_page = site.pages | where: "path", path | first -%}
             {%- if my_page.title -%}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -18,7 +18,7 @@
         </label>
 
         <div class="trigger">
-          <a class="page-link" id="search-toggle">Search</a>
+          {% if page.taxon %}<a class="page-link" id="search-toggle">Search</a>{% endif %}
           {%- for path in page_paths -%}
             {%- assign my_page = site.pages | where: "path", path | first -%}
             {%- if my_page.title -%}

--- a/_includes/search.html
+++ b/_includes/search.html
@@ -1,0 +1,54 @@
+<style>
+  ul.toc li.ellipsis {
+    height: 0;
+    overflow: hidden;
+  }
+  section.ellipsis > header {
+    opacity: 0.5;
+    border-bottom: 3px dashed black;
+  }
+  section.ellipsis > :not(header) {
+    display: none;
+  }
+  #search-form {
+    margin-bottom: 2rem;
+  }
+  #search-form fieldset {
+    display: flex;
+    flex-wrap: wrap;
+  }
+  #search-form input {
+    flex-grow: 1;
+  }
+  #search-form .hint {
+    flex-basis: 100%;
+    margin: 0;
+  }
+  #search-form .hint summary {
+    font-size: small;
+  }
+</style>
+
+<script src="{{ 'assets/search.js' | relative_url }}"></script>
+
+<form id="search-form" hidden>
+  <fieldset>
+    <legend>Search</legend>
+    <input autocomplete="off" type="search" id="search-query" name="q" placeholder="Search...."/>
+    <button type="submit">Search</button>
+    <button type="reset">Clear</button>
+    <details class="hint">
+      <summary>Click here for help.</summary>
+      <ul>
+        <li>You can type your query in the input box, click "Search" to start the search, and click "Clear" to clear the page.</li>
+        <li>The search happens on the current page. If you want to extend it, navigate the book upwards. A search on the root note will search the whole book.</li>
+        <li>Once the search is completed, matches will be highlighted and nodes with no matches will be folded. You can expand them by clicking.</li>
+        <li>Multiple terms are allowed in the query and the default behaviour is <code>OR</code>ing them. You can <code>AND</code> terms making them mandatory, see <code>+foo</code> below.</li>
+        <li><code>*foo</code>, <code>f*o</code>, and <code>fo*</code> are all allowed wildcards.</li>
+        <li><code>+foo</code> makes a term mandatory, while <code>-foo</code> makes a term forbidden.</li>
+        <li><code>foo~n</code> fuzzy matches within edit distance <code>n</code> (a positive number) from the term.</li>
+        <li>Note that the URL changes after a search. You can copy and paste it to share your search results. They will be displayed immediately upon visiting the URL.</li>
+      </ul>
+    </details>
+  </fieldset>
+</form>

--- a/_layouts/sheafy/node/result.md
+++ b/_layouts/sheafy/node/result.md
@@ -1,8 +1,8 @@
-<section>
+<section id="{{ page.slug }}">
 
 {::nomarkdown}
 
-<header class="inline" id="{{ page.slug }}">
+<header class="inline">
   <a class="slug" href="{{ page.url | relative_url }}">[{{ page.slug }}]</a>
   {{page | display_title_parenthetical -}}.
 </header>

--- a/_layouts/sheafy/node/section.md
+++ b/_layouts/sheafy/node/section.md
@@ -1,8 +1,8 @@
-<section>
+<section id="{{ page.slug }}">
 
 {::nomarkdown}
 
-<header id="{{ page.slug }}">
+<header>
   <h{{ page.depth | plus: 1 }}>
     {% if page.depth == 0 %}
       {{ page.title }}

--- a/_layouts/sheafy/tree/default.html
+++ b/_layouts/sheafy/tree/default.html
@@ -3,6 +3,10 @@ layout: default
 ---
 
 <style>
+  ul.toc li.ellipsis {
+    height: 0;
+    overflow: hidden;
+  }
   section.ellipsis > header {
     opacity: 0.5;
     border-bottom: 3px dashed black;

--- a/_layouts/sheafy/tree/default.html
+++ b/_layouts/sheafy/tree/default.html
@@ -10,26 +10,31 @@ layout: default
   section.ellipsis > :not(header) {
     display: none;
   }
-  form.search {
+  #search-form {
     margin-bottom: 2rem;
   }
-  form.search fieldset {
+  #search-form fieldset {
     display: flex;
-    padding: 0;
-    border: none;
+    flex-wrap: wrap;
   }
-  form.search input {
+  #search-form input {
     flex-grow: 1;
+  }
+  #search-form .hint {
+    flex-basis: 100%;
+    margin: 0;
   }
 </style>
 
 <script src="{{ 'assets/in_page_search.js' | relative_url }}"></script>
 
-<form class="search" action="{{ 'search' | relative_url }}" method="GET">
+<form id="search-form" hidden>
   <fieldset>
+    <legend>Search</legend>
     <input autocomplete="off" type="search" id="search-query" name="q" placeholder="Search...."/>
     <button type="submit">Search</button>
     <button type="reset">Clear</button>
+    <p class="hint">Some hints about searching effectively should be here.</p>
   </fieldset>
 </form>
 

--- a/_layouts/sheafy/tree/default.html
+++ b/_layouts/sheafy/tree/default.html
@@ -2,60 +2,7 @@
 layout: default
 ---
 
-<style>
-  ul.toc li.ellipsis {
-    height: 0;
-    overflow: hidden;
-  }
-  section.ellipsis > header {
-    opacity: 0.5;
-    border-bottom: 3px dashed black;
-  }
-  section.ellipsis > :not(header) {
-    display: none;
-  }
-  #search-form {
-    margin-bottom: 2rem;
-  }
-  #search-form fieldset {
-    display: flex;
-    flex-wrap: wrap;
-  }
-  #search-form input {
-    flex-grow: 1;
-  }
-  #search-form .hint {
-    flex-basis: 100%;
-    margin: 0;
-  }
-  #search-form .hint summary {
-    font-size: small;
-  }
-</style>
-
-<script src="{{ 'assets/in_page_search.js' | relative_url }}"></script>
-
-<form id="search-form" hidden>
-  <fieldset>
-    <legend>Search</legend>
-    <input autocomplete="off" type="search" id="search-query" name="q" placeholder="Search...."/>
-    <button type="submit">Search</button>
-    <button type="reset">Clear</button>
-    <details class="hint">
-      <summary>Click here for help.</summary>
-      <ul>
-        <li>You can type your query in the input box, click "Search" to start the search, and click "Clear" to clear the page.</li>
-        <li>The search happens on the current page. If you want to extend it, navigate the book upwards. A search on the root note will search the whole book.</li>
-        <li>Once the search is completed, matches will be highlighted and nodes with no matches will be folded. You can expand them by clicking.</li>
-        <li>Multiple terms are allowed in the query and the default behaviour is <code>OR</code>ing them. You can <code>AND</code> terms making them mandatory, see <code>+foo</code> below.</li>
-        <li><code>*foo</code>, <code>f*o</code>, and <code>fo*</code> are all allowed wildcards.</li>
-        <li><code>+foo</code> makes a term mandatory, while <code>-foo</code> makes a term forbidden.</li>
-        <li><code>foo~n</code> fuzzy matches within edit distance <code>n</code> (a positive number) from the term.</li>
-        <li>Note that the URL changes after a search. You can copy and paste it to share your search results. They will be displayed immediately upon visiting the URL.</li>
-      </ul>
-    </details>
-  </fieldset>
-</form>
+{% include search.html %}
 
 <article class="post">
   <nav>

--- a/_layouts/sheafy/tree/default.html
+++ b/_layouts/sheafy/tree/default.html
@@ -24,6 +24,9 @@ layout: default
     flex-basis: 100%;
     margin: 0;
   }
+  #search-form .hint summary {
+    font-size: small;
+  }
 </style>
 
 <script src="{{ 'assets/in_page_search.js' | relative_url }}"></script>
@@ -34,7 +37,18 @@ layout: default
     <input autocomplete="off" type="search" id="search-query" name="q" placeholder="Search...."/>
     <button type="submit">Search</button>
     <button type="reset">Clear</button>
-    <p class="hint">Some hints about searching effectively should be here.</p>
+    <details class="hint">
+      <summary>Click here for help.</summary>
+      <ul>
+        <li>You can type your query in the input box, click "Search" to start the search, and click "Clear" to clear the page.</li>
+        <li>Once the search is completed, matches will be highlighted and nodes with no matches will be folded. You can expand them by clicking.</li>
+        <li>Multiple terms are allowed in the query and the default behaviour is <code>OR</code>ing them.</li>
+        <li><code>*foo</code>, <code>f*o</code>, and <code>fo*</code> are all allowed wildcards.</li>
+        <li><code>+foo</code> makes a term mandatory, while <code>-foo</code> makes a term forbidden.</li>
+        <li><code>foo~n</code> fuzzy matches within edit distance <code>n</code> (a positive number) from the term.</li>
+        <li>Note that the URL changes after a search. You can copy and paste it to share your search results. They will be displayed immediately upon visiting the URL.</li>
+      </ul>
+    </details>
   </fieldset>
 </form>
 

--- a/_layouts/sheafy/tree/default.html
+++ b/_layouts/sheafy/tree/default.html
@@ -42,7 +42,7 @@ layout: default
       <ul>
         <li>You can type your query in the input box, click "Search" to start the search, and click "Clear" to clear the page.</li>
         <li>Once the search is completed, matches will be highlighted and nodes with no matches will be folded. You can expand them by clicking.</li>
-        <li>Multiple terms are allowed in the query and the default behaviour is <code>OR</code>ing them.</li>
+        <li>Multiple terms are allowed in the query and the default behaviour is <code>OR</code>ing them. You can <code>AND</code> terms making them mandatory, see <code>+foo</code> below.</li>
         <li><code>*foo</code>, <code>f*o</code>, and <code>fo*</code> are all allowed wildcards.</li>
         <li><code>+foo</code> makes a term mandatory, while <code>-foo</code> makes a term forbidden.</li>
         <li><code>foo~n</code> fuzzy matches within edit distance <code>n</code> (a positive number) from the term.</li>

--- a/_layouts/sheafy/tree/default.html
+++ b/_layouts/sheafy/tree/default.html
@@ -2,6 +2,37 @@
 layout: default
 ---
 
+<style>
+  section.ellipsis > header {
+    opacity: 0.5;
+    border-bottom: 3px dashed black;
+  }
+  section.ellipsis > :not(header) {
+    display: none;
+  }
+  form.search {
+    margin-bottom: 2rem;
+  }
+  form.search fieldset {
+    display: flex;
+    padding: 0;
+    border: none;
+  }
+  form.search input {
+    flex-grow: 1;
+  }
+</style>
+
+<script src="{{ 'assets/in_page_search.js' | relative_url }}"></script>
+
+<form class="search" action="{{ 'search' | relative_url }}" method="GET">
+  <fieldset>
+    <input autocomplete="off" type="search" id="search-query" name="q" placeholder="Search...."/>
+    <button type="submit">Search</button>
+    <button type="reset">Clear</button>
+  </fieldset>
+</form>
+
 <article class="post">
   <nav>
     {% include breadcrumbs.html list=page.ancestors %}

--- a/_layouts/sheafy/tree/default.html
+++ b/_layouts/sheafy/tree/default.html
@@ -41,6 +41,7 @@ layout: default
       <summary>Click here for help.</summary>
       <ul>
         <li>You can type your query in the input box, click "Search" to start the search, and click "Clear" to clear the page.</li>
+        <li>The search happens on the current page. If you want to extend it, navigate the book upwards. A search on the root note will search the whole book.</li>
         <li>Once the search is completed, matches will be highlighted and nodes with no matches will be folded. You can expand them by clicking.</li>
         <li>Multiple terms are allowed in the query and the default behaviour is <code>OR</code>ing them. You can <code>AND</code> terms making them mandatory, see <code>+foo</code> below.</li>
         <li><code>*foo</code>, <code>f*o</code>, and <code>fo*</code> are all allowed wildcards.</li>

--- a/assets/in_page_search.js
+++ b/assets/in_page_search.js
@@ -72,21 +72,21 @@ class InPageSearch {
 
   async run(q) {
     this.lazyInit();
-    // TODO: lock form
+    await this.setFormLock(true);
     const results = this.searchIndex(q);
     this.setVisibilities(false);
     await this.promiseToUnmarkDocument();
     await this.promiseToMarkDocument(results);
     this.applyVisibilities();
-    // TODO: unlock form
+    await this.setFormLock(false);
   }
 
   async clear() {
-    // TODO: lock form
+    await this.setFormLock(true);
     await this.promiseToUnmarkDocument();
     this.setVisibilities(true);
     this.applyVisibilities();
-    // TODO: unlock form
+    await this.setFormLock(false);
   }
 
   promiseToMarkSection(section, terms) {
@@ -150,6 +150,16 @@ class InPageSearch {
       this.handleOnInput.bind(this),
       false
     );
+  }
+
+  async setFormLock(locked) {
+    this.form.querySelector("fieldset").disabled = locked;
+    // we need to give slow machines some time to redraw
+    await this.sleep(1);
+  }
+
+  sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 }
 

--- a/assets/in_page_search.js
+++ b/assets/in_page_search.js
@@ -4,6 +4,7 @@ class InPageSearch {
     this.FOLDED_CLASS = "ellipsis";
     this.MARKJS_EXCLUDE_FOLDED = ".ellipsis *";
     this.INPUT_NAME = "q";
+    this.URL_PARAM = "q";
     this.DOC_REF_KEY = "slug";
     this.DOC_VAL_KEY = "text";
 
@@ -17,6 +18,8 @@ class InPageSearch {
     this.nodeElements = {};
     this.nodeVisibilities = {};
     this.initialized = false;
+
+    this.checkURL();
   }
 
   //=[ Initialization ]=========================================================
@@ -46,6 +49,36 @@ class InPageSearch {
       .join("\n");
   }
 
+  //=[ URI ]====================================================================
+
+  checkURL() {
+    const q = this.getURLQuery();
+    if (q) {
+      this.handleToggle();
+      this.input.value = q;
+      this.run(q);
+    }
+  }
+
+  getURLQuery() {
+    var url = new URL(window.location.href);
+    return url.searchParams.get(this.URL_PARAM);
+  }
+
+  setURLQuery(q) {
+    if (!history.replaceState) return;
+    var url = new URL(window.location.href);
+    url.searchParams.set(this.URL_PARAM, q);
+    window.history.replaceState(null, null, url);
+  }
+
+  deleteURLQuery() {
+    if (!history.replaceState) return;
+    var url = new URL(window.location.href);
+    url.searchParams.delete(this.URL_PARAM);
+    window.history.replaceState(null, null, url);
+  }
+
   //=[ Operation ]==============================================================
 
   async run(q) {
@@ -63,6 +96,8 @@ class InPageSearch {
     await this.promiseToMarkTree(results);
 
     await this.setFormLock(false);
+
+    this.setURLQuery(q);
   }
 
   async clear() {
@@ -74,6 +109,8 @@ class InPageSearch {
     this.applyVisibilities();
 
     await this.setFormLock(false);
+
+    this.deleteURLQuery();
   }
 
   //=[ Indexing ]===============================================================

--- a/assets/in_page_search.js
+++ b/assets/in_page_search.js
@@ -1,0 +1,141 @@
+class InPageSearch {
+  constructor() {
+    this.searchResults = document.getElementById("results");
+    this.form = document.querySelector("form");
+    this.input = document.getElementById("search-query");
+    this.bindEvents();
+
+    this.data = [];
+    this.sections = {};
+    this.visibilities = {};
+    this.initialized = false;
+  }
+
+  applyVisibilities() {
+    Object.entries(this.visibilities).forEach(([slug, visible]) => {
+      if (visible) {
+        this.sections[slug].classList.remove("ellipsis");
+      } else {
+        this.sections[slug].classList.add("ellipsis");
+      }
+    });
+  }
+
+  async lazyInit() {
+    if (this.initialized) return;
+    document.querySelectorAll("section").forEach((element) => {
+      this.sections[element.id] = element;
+      this.visibilities[element.id] = true;
+      const text = [...element.children]
+        .filter((e) => e.nodeName != "SECTION")
+        .map((e) => e.innerText)
+        .join("\n");
+      this.data.push({
+        slug: element.id,
+        text: text,
+      });
+    });
+    this.initIndex(this.data);
+    this.initialized = true;
+  }
+
+  initIndex(data) {
+    this.index ||= lunr(function () {
+      this.ref("slug");
+      this.field("text");
+      data.forEach(function (doc) {
+        this.add(doc);
+      }, this);
+    });
+  }
+
+  searchIndex(query) {
+    return this.index.search(query);
+  }
+
+  handleOnInput(event) {
+    this.run(event.target.value);
+  }
+
+  async handleReset(event) {
+    await this.clear();
+  }
+
+  async handleSubmit(event) {
+    event.preventDefault();
+    var data = new FormData(event.target);
+    var q = data.get("q");
+    await this.run(q);
+  }
+
+  async run(q) {
+    this.lazyInit();
+    // TODO: lock form
+    const results = this.searchIndex(q);
+    this.setAllVisibilities(false);
+    await this.promiseToUnmarkDocument();
+    await this.promiseToMarkDocument(results);
+    this.applyVisibilities();
+    // TODO: unlock form
+  }
+
+  async clear() {
+    // TODO: lock form
+    await this.promiseToUnmarkDocument();
+    this.setAllVisibilities(true);
+    this.applyVisibilities();
+    // TODO: unlock form
+  }
+
+  promiseToMarkSection(section, terms) {
+    return new Promise((resolve, reject) => {
+      // TODO: fix spurious highlights, e.g. (co)cartesian
+      new Mark(section).mark(terms, { exclude: "section", done: resolve });
+    });
+  }
+
+  showSectionAndAncestors(node) {
+    if (node.nodeName != "SECTION") return;
+    if (this.visibilities[node.id]) return;
+    this.visibilities[node.id] = true;
+    this.showSectionAndAncestors(node.parentNode);
+  }
+
+  promiseToMarkDocument(results) {
+    const promisesToMarkSections = results.map(
+      ({ ref, matchData: { metadata } }) => {
+        const section = this.sections[ref];
+        this.showSectionAndAncestors(section);
+        this.promiseToMarkSection(section, Object.keys(metadata));
+      }
+    );
+
+    return Promise.allSettled(promisesToMarkSections);
+  }
+
+  promiseToUnmarkDocument() {
+    return new Promise((resolve, reject) => {
+      new Mark(document).unmark({ done: resolve });
+    });
+  }
+
+  setAllVisibilities(status) {
+    Object.keys(this.visibilities).forEach(
+      (slug) => (this.visibilities[slug] = status)
+    );
+  }
+
+  bindEvents() {
+    this.form.addEventListener("submit", this.handleSubmit.bind(this), false);
+    this.form.addEventListener("reset", this.handleReset.bind(this), false);
+    this.input.addEventListener(
+      "keydown keyup",
+      this.handleOnInput.bind(this),
+      false
+    );
+  }
+}
+
+document.addEventListener("DOMContentLoaded", function () {
+  window.inPageSearch = new InPageSearch();
+});

--- a/assets/in_page_search.js
+++ b/assets/in_page_search.js
@@ -2,7 +2,10 @@ class InPageSearch {
   constructor() {
     this.NODE_TAG = "SECTION"; // MUST be uppercase to be both selector and nodeName
     this.FOLDED_CLASS = "ellipsis";
-    this.MARKJS_EXCLUDE_FOLDED = ".ellipsis *";
+    this.MARKJS_EXCLUSIONS = [
+      `.${this.FOLDED_CLASS} *`, // folded nodes
+      "nav *", // toc, next/prev, etc.
+    ];
     this.INPUT_NAME = "q";
     this.URL_PARAM = "q";
     this.DOC_REF_KEY = "slug";
@@ -170,7 +173,8 @@ class InPageSearch {
   promiseToMarkNode(slug, terms) {
     return new Promise((resolve, reject) => {
       new Mark(this.nodeElements[slug]).mark(terms, {
-        exclude: [this.MARKJS_EXCLUDE_FOLDED],
+        exclude: this.MARKJS_EXCLUSIONS,
+        accuracy: "complementary",
         done: resolve,
       });
     });

--- a/assets/in_page_search.js
+++ b/assets/in_page_search.js
@@ -228,6 +228,7 @@ class InPageSearch {
 
   handleToggle() {
     this.form.hidden = !this.form.hidden;
+    if (!this.form.hidden) this.input.focus();
   }
 
   bindEvents() {

--- a/assets/in_page_search.js
+++ b/assets/in_page_search.js
@@ -12,13 +12,15 @@ class InPageSearch {
   }
 
   applyVisibilities() {
-    Object.entries(this.visibilities).forEach(([slug, visible]) => {
-      if (visible) {
-        this.sections[slug].classList.remove("ellipsis");
-      } else {
-        this.sections[slug].classList.add("ellipsis");
-      }
-    });
+    Object.keys(this.visibilities).forEach(this.applyVisibility.bind(this));
+  }
+
+  applyVisibility(slug) {
+    if (this.visibilities[slug]) {
+      this.sections[slug].classList.remove("ellipsis");
+    } else {
+      this.sections[slug].classList.add("ellipsis");
+    }
   }
 
   async lazyInit() {
@@ -72,7 +74,7 @@ class InPageSearch {
     this.lazyInit();
     // TODO: lock form
     const results = this.searchIndex(q);
-    this.setAllVisibilities(false);
+    this.setVisibilities(false);
     await this.promiseToUnmarkDocument();
     await this.promiseToMarkDocument(results);
     this.applyVisibilities();
@@ -82,7 +84,7 @@ class InPageSearch {
   async clear() {
     // TODO: lock form
     await this.promiseToUnmarkDocument();
-    this.setAllVisibilities(true);
+    this.setVisibilities(true);
     this.applyVisibilities();
     // TODO: unlock form
   }
@@ -119,13 +121,26 @@ class InPageSearch {
     });
   }
 
-  setAllVisibilities(status) {
+  setVisibilities(status) {
     Object.keys(this.visibilities).forEach(
-      (slug) => (this.visibilities[slug] = status)
+      this.setVisibility.bind(this, status)
     );
   }
 
+  setVisibility(status, slug) {
+    this.visibilities[slug] = status;
+  }
+
+  handleClick(event) {
+    if (!this.initialized) return;
+    const slug = event.target.closest("section").id;
+    if (this.visibilities[slug]) return;
+    this.setVisibility(true, slug);
+    this.applyVisibility(slug);
+  }
+
   bindEvents() {
+    document.addEventListener("click", this.handleClick.bind(this), false);
     this.form.addEventListener("submit", this.handleSubmit.bind(this), false);
     this.form.addEventListener("reset", this.handleReset.bind(this), false);
     this.input.addEventListener(

--- a/assets/in_page_search.js
+++ b/assets/in_page_search.js
@@ -1,7 +1,7 @@
 class InPageSearch {
   constructor() {
     this.searchResults = document.getElementById("results");
-    this.form = document.querySelector("form");
+    this.form = document.getElementById("search-form");
     this.input = document.getElementById("search-query");
     this.bindEvents();
 
@@ -141,6 +141,10 @@ class InPageSearch {
     this.applyVisibility(slug);
   }
 
+  handleToggle() {
+    this.form.hidden = !this.form.hidden;
+  }
+
   bindEvents() {
     document.addEventListener("click", this.handleClick.bind(this), false);
     this.form.addEventListener("submit", this.handleSubmit.bind(this), false);
@@ -150,6 +154,9 @@ class InPageSearch {
       this.handleOnInput.bind(this),
       false
     );
+    document
+      .getElementById("search-toggle")
+      .addEventListener("click", this.handleToggle.bind(this), false);
   }
 
   async setFormLock(locked) {

--- a/assets/in_page_search.js
+++ b/assets/in_page_search.js
@@ -133,7 +133,9 @@ class InPageSearch {
 
   handleClick(event) {
     if (!this.initialized) return;
-    const slug = event.target.closest("section").id;
+    const section = event.target.closest("section");
+    if (!section) return;
+    const slug = section.id;
     if (this.visibilities[slug]) return;
     this.setVisibility(true, slug);
     this.applyVisibility(slug);

--- a/assets/in_page_search.js
+++ b/assets/in_page_search.js
@@ -17,6 +17,7 @@ class InPageSearch {
     this.toggle = document.getElementById("search-toggle");
     this.bindEvents();
 
+    this.tocItems = {};
     this.nodeDocuments = [];
     this.nodeElements = {};
     this.nodeVisibilities = {};
@@ -36,6 +37,10 @@ class InPageSearch {
 
   initBookkeeping() {
     document.querySelectorAll(this.NODE_TAG).forEach((element) => {
+      this.tocItems[element.id] = document
+        .querySelector(".toc")
+        .querySelector(`a[href="#${element.id}"]`)
+        ?.closest("li");
       this.nodeElements[element.id] = element;
       this.nodeVisibilities[element.id] = true;
       this.nodeDocuments.push({
@@ -162,8 +167,10 @@ class InPageSearch {
 
   applyVisibility(slug) {
     if (this.nodeVisibilities[slug]) {
+      this.tocItems[slug]?.classList?.remove(this.FOLDED_CLASS);
       this.nodeElements[slug].classList.remove(this.FOLDED_CLASS);
     } else {
+      this.tocItems[slug]?.classList?.add(this.FOLDED_CLASS);
       this.nodeElements[slug].classList.add(this.FOLDED_CLASS);
     }
   }

--- a/assets/search.js
+++ b/assets/search.js
@@ -1,4 +1,4 @@
-class InPageSearch {
+class Search {
   constructor() {
     this.NODE_TAG = "SECTION"; // MUST be uppercase to be both selector and nodeName
     this.FOLDED_CLASS = "ellipsis";
@@ -251,5 +251,5 @@ class InPageSearch {
 }
 
 document.addEventListener("DOMContentLoaded", function () {
-  window.inPageSearch = new InPageSearch();
+  window.search = new Search();
 });


### PR DESCRIPTION
Here's a neat new toy, @jonsterling. :grin:

I spent some time thinking about a search feature.

I prototyped one similar to the Stacks' one. It is definitely feasible but I didn't complete it. Our use-case is "many minibooks" and not "one gigabook", and this makes the implementation more complex and the result less effective, or at the very least underwhelming, I think.

Fortunately that gave me an idea: the Stacks-like implementation needed an alternative rendering of *all* the nodes (w/o flattened children) as a database to index -- but what if we used the pages that we already rendered? :exploding_head:

In short: what I implemented uses the DOM of the page you're visiting to index and search the subtree below its root node. If you want to search the whole minibook instead, you just go and visit its root. Furthermore:
* the page is pruned of the branches without results (only the heading of their root is visible and shaded)
* all matches are highlighted
* the search algorithm is fuzzy and also accepts a [decent query language](https://lunrjs.com/guides/searching.html)

Here's an example:

![image](https://user-images.githubusercontent.com/2499655/152051881-bbc23e02-c404-47e2-a139-fb918b7d73f7.png)

This is pretty simple to implement and it circumvents a lot of problems I found trying to imitate Stacks more closely.

Also, I think it's cooler. :laughing: 

Some more ideas:
- [x] find somewhere in the layout to put the search bar
- [x] give the user some feedback during the calculations, e.g. (un)locking the form
- [x] make the collapsed sections unfoldable on click
- [x] finetune the match highlighting and the query language options
- [x] enable reading the search from a parameter in the url, e.g. http://localhost:4000/math/lectures/categorical-foundations.html?q=cartesian would get you to a page with all the occurences of "cartesian" already highlighted and the irrelevant nodes collapsed (but unfoldable) -- wouldn't that be cool?

Let me know what you think! :smile: 