### PR TITLE
Minor typo in codomain of the vertical map in the fibred opposite

### DIFF
--- a/_nodes/001Z.md
+++ b/_nodes/001Z.md
@@ -9,7 +9,7 @@ $\OpCat{E}$ over $B$ like so:
 
 2. Given $f : x \to y\in B$, a morphism $\bar{x}\to_f \bar{y}$ in $\OpCat{E}$
    is given in terms of $E$ by a cartesian map $\bar{y}\Sub{f} : \bar{y}\Sub{x} \to\Sub{f} \bar{y}$ together
-   with a *vertical* map $h : \bar{y}\Sub{x}\to\Sub{\Idn{x}} \bar{y}$ as depicted below:
+   with a *vertical* map $h : \bar{y}\Sub{x}\to\Sub{\Idn{x}} \bar{x}$ as depicted below:
    {%tex macrolib: topos%}
     \begin{tikzpicture}[diagram]
       \SpliceDiagramSquare{


### PR DESCRIPTION
The text says that we should have a vertical map `y_x → y`, but the diagram displays (ha) a map `y_x → x`.